### PR TITLE
Fix: Fix column names.

### DIFF
--- a/db/migrate/20200127091213_rename_columns.rb
+++ b/db/migrate/20200127091213_rename_columns.rb
@@ -1,0 +1,17 @@
+class RenameColumns < ActiveRecord::Migration[5.2]
+
+  def up
+    rename_column :genres, :genres_status, :status
+    rename_column :items, :genres_id, :genre_id
+    rename_column :items, :item_status, :status
+    rename_column :orders, :order_status, :status
+  end
+
+  # to rollback
+  def down
+    rename_column :genres, :status, :genres_status
+    rename_column :items, :genre_id, :genres_id
+    rename_column :items, :status, :item_status
+    rename_column :orders, :status, :order_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_25_114702) do
+ActiveRecord::Schema.define(version: 2020_01_27_091213) do
 
   create_table "addresses", force: :cascade do |t|
     t.string "name", null: false
@@ -64,15 +64,15 @@ ActiveRecord::Schema.define(version: 2020_01_25_114702) do
 
   create_table "genres", force: :cascade do |t|
     t.string "name", null: false
-    t.integer "genres_status", null: false
+    t.integer "status", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "items", force: :cascade do |t|
     t.string "name", null: false
-    t.integer "genres_id", null: false
-    t.integer "item_status", null: false
+    t.integer "genre_id", null: false
+    t.integer "status", null: false
     t.text "caption", null: false
     t.integer "price", null: false
     t.string "image_id", null: false
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2020_01_25_114702) do
     t.string "name", null: false
     t.string "zipcode", null: false
     t.string "address", null: false
-    t.integer "order_status", null: false
+    t.integer "status", null: false
     t.integer "sum_price", null: false
     t.integer "shipping_price", null: false
     t.integer "payment_price", null: false


### PR DESCRIPTION
下記テーブルのカラム名を 修正しました。

```
genres テーブル
genres_status -> status

items テーブル 
genres_id -> genre_id
item_status -> status

orders テーブル
order_status -> status
```

ご確認お願いいたします。